### PR TITLE
Fix for issue with new non-deprecated selectors

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,55 +1,46 @@
 @import "syntax-variables";
 
-atom-text-editor {
+atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
-}
-
-atom-text-editor .gutter {
-  background-color: @syntax-gutter-background-color;
-  color: @syntax-gutter-text-color;
-}
-
-atom-text-editor .gutter .line-number.cursor-line {
-  background-color: @syntax-gutter-background-color-selected;
-  color: @syntax-gutter-text-color-selected;
-}
-
-atom-text-editor .gutter .line-number.cursor-line-no-selection {
-  color: @syntax-gutter-text-color-selected;
-}
-
-atom-text-editor .wrap-guide {
-  color: @syntax-wrap-guide-color;
-}
-
-atom-text-editor .indent-guide {
-  color: @syntax-indent-guide-color;
-}
-
-atom-text-editor .invisible-character {
-  color: @syntax-invisible-character-color;
-}
-
-atom-text-editor .search-results .marker .region {
-  background-color: transparent;
-  border: @syntax-result-marker-color;
-}
-
-atom-text-editor .search-results .marker.current-result .region {
-  border: @syntax-result-marker-color-selected;
-}
-
-atom-text-editor.is-focused .cursor {
-  border-color: @syntax-cursor-color;
-}
-
-atom-text-editor.is-focused .selection .region {
-  background-color: @syntax-selection-color;
-}
-
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
-  background-color: #2d3038;
+  
+  .gutter {
+    background-color: @syntax-gutter-background-color;
+    color: @syntax-gutter-text-color;
+  }
+  
+  .gutter .line-number.cursor-line {
+    background-color: @syntax-gutter-background-color-selected;
+    color: @syntax-gutter-text-color-selected;
+  }
+  
+  .gutter .line-number.cursor-line-no-selection {
+    color: @syntax-gutter-text-color-selected;
+  }
+  
+  .wrap-guide {
+    color: @syntax-wrap-guide-color;
+  }
+  
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
+  
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
+  
+  .is-focused .cursor {
+    border-color: @syntax-cursor-color;
+  }
+  
+  .is-focused .selection .region {
+    background-color: @syntax-selection-color;
+  }
+  
+  .is-focused .line-number.cursor-line-no-selection, .is-focused .line.cursor-line {
+    background-color: #2d3038;
+  }
 }
 
 .comment {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -12,10 +12,6 @@
 @syntax-indent-guide-color: #3B3A32;
 @syntax-invisible-character-color: #3B3A32;
 
-// For find and replace markers
-@syntax-result-marker-color: #3B3A32;
-@syntax-result-marker-color-selected: #d6d7d9;
-
 // Gutter colors
 @syntax-gutter-text-color: #d6d7d9;
 @syntax-gutter-text-color-selected: #d6d7d9;


### PR DESCRIPTION
Looks like I didn't do enough testing before! Apparently it wasn't as simple as a replace .editor with atom-text-editor like I believed. Some of the selectors were no longer working, in particular the highlighted regions color when you select lines.

I've moved all of the atom-text-editor selectors under the new format of:

```
atom-text-editor, :host {
  ...
}
```

which targets both the shadow dom and non-shadow dom should you decide to disable it. This follows the examples shown here: https://atom.io/docs/v0.186.0/upgrading/upgrading-your-ui-theme as well as a few of the popular syntax themes.


Additionally, I pulled out the search-results selectors. I did some testing with those and I don't think those have been working for quite some time.