### PR TITLE
Added back search/replace selectors and colors

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -30,6 +30,15 @@ atom-text-editor, :host {
     color: @syntax-invisible-character-color;
   }
   
+  .find-result .region {
+      background-color: transparent;
+      border-color: @syntax-result-marker-color;
+  }
+  
+  .current-result .region {
+      border-color: @syntax-result-marker-color-selected;
+  }
+  
   .is-focused .cursor {
     border-color: @syntax-cursor-color;
   }

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -12,6 +12,10 @@
 @syntax-indent-guide-color: #3B3A32;
 @syntax-invisible-character-color: #3B3A32;
 
+// For find and replace markers
+@syntax-result-marker-color: #3B3A32;
+@syntax-result-marker-color-selected: #d6d7d9;
+
 // Gutter colors
 @syntax-gutter-text-color: #d6d7d9;
 @syntax-gutter-text-color-selected: #d6d7d9;


### PR DESCRIPTION
This should be the last PR, thanks for pulling the others in!

Added back the search/replace colors with updated selectors. Did an attempt to try and get it to parity with the Sublime Text version, but it looks like Atom still doesn't let you change the color of highlighted text since the highlight is an absolute positioned div underlay. There didn't seem to be any selectors that would hint at being a find region either which is too bad.